### PR TITLE
Added Windows compatibility

### DIFF
--- a/lib/dash.coffee
+++ b/lib/dash.coffee
@@ -1,5 +1,7 @@
 basename = require('path').basename
 spawn = require('child_process').spawn
+exec = require('child_process').exec
+platform = require('process').platform
 grammarMap = require('./grammar-map')
 filenameMap = require('./filename-map')
 
@@ -55,7 +57,17 @@ plugin = module.exports =
       path = activeEditor.getPath()
       language = activeEditor.getGrammar().name
 
-    spawn('open', ['-g', @createLink(string, path, language)])
+    if platform == "win32"
+      # Exec is used because spawn escapes arguments that contain double-quotes
+      # and replaces them with backslashes. This interferes with the ability to
+      # properly create the child process in windows, since windows will barf
+      # on an ampersand that is not contained in double-quotes.
+      quotedLink = '"' + @createLink(string, path, language) + '"'
+      exec('cmd.exe /c start "" ' + quotedLink, null)
+    else if platform == "linux"
+      spawn('xdg-open', [@createLink(string, path, language)])
+    else  # Darwin (OSX) / FreeBSD 
+      spawn('open', ['-g', @createLink(string, path, language)])
 
   createLink: (string, path, language) ->
     keys = []

--- a/lib/dash.coffee
+++ b/lib/dash.coffee
@@ -64,9 +64,9 @@ plugin = module.exports =
       # on an ampersand that is not contained in double-quotes.
       quotedLink = '"' + @createLink(string, path, language) + '"'
       exec('cmd.exe /c start "" ' + quotedLink, null)
-    else if platform == "linux"
-      spawn('xdg-open', [@createLink(string, path, language)])
-    else  # Darwin (OSX) / FreeBSD 
+    #else if platform == "linux"  ## Zeal is the only linux alternative and it does not support Dash urls at this point
+    #  spawn('xdg-open', [@createLink(string, path, language)])
+    else  # Darwin (OSX) / FreeBSD
       spawn('open', ['-g', @createLink(string, path, language)])
 
   createLink: (string, path, language) ->

--- a/lib/dash.coffee
+++ b/lib/dash.coffee
@@ -57,14 +57,14 @@ plugin = module.exports =
       path = activeEditor.getPath()
       language = activeEditor.getGrammar().name
 
-    if platform == "win32"
+    if platform == 'win32'
       # Exec is used because spawn escapes arguments that contain double-quotes
       # and replaces them with backslashes. This interferes with the ability to
       # properly create the child process in windows, since windows will barf
       # on an ampersand that is not contained in double-quotes.
       quotedLink = '"' + @createLink(string, path, language) + '"'
       exec('cmd.exe /c start "" ' + quotedLink, null)
-    #else if platform == "linux"  ## Zeal is the only linux alternative and it does not support Dash urls at this point
+    #else if platform == 'linux'  ## Zeal is the only linux alternative and it does not support Dash urls at this point
     #  spawn('xdg-open', [@createLink(string, path, language)])
     else  # Darwin (OSX) / FreeBSD
       spawn('open', ['-g', @createLink(string, path, language)])


### PR DESCRIPTION
Thanks for the great plugin! 

I'm frequently moving between OS environments for work and have Dash analogues in these environments and felt that adding the support to this plugin was better than starting from scratch, so I forked with my local changes and added Windows compatibility so tools like Velocity (https://velocity.silverlakesoftware.com/) which support the Dash protocols will work in their native environments.

I've tested the changes on both OSX and Window, but it would be good to have another set of eyes ensure that I haven't broken anything. 

I had originally added Linux support, but Zeal is the only alternative on Linux and it uses a different protocol than Dash.  I have that support commented out for the moment, and it should be easy to re-enable in the future should Zeal add the Dash protocols.  The Linux implementation uses ```xdg-open```, which is not installed by default all Linux distros.  So there is no way to ensure that it will work in 100% of Linux environments without additional setup. 