### PR TITLE
Add support for SCSS to the default grammar map

### DIFF
--- a/lib/grammar-map.coffee
+++ b/lib/grammar-map.coffee
@@ -7,6 +7,13 @@ css = [
   'phonegap'
 ]
 
+sass = [
+  'sass',
+  'compass',
+  'bourbon',
+  'neat'
+].concat(css)
+
 js = [
   'javascript',
   'jquery',
@@ -229,12 +236,8 @@ module.exports =
   'Rust': [
     'rust'
   ]
-  'Sass': [
-    'sass',
-    'compass',
-    'bourbon',
-    'neat'
-  ].concat(css)
+  'Sass': sass
+  'SCSS': sass
   'Scala': [
     'scala',
     'akka',


### PR DESCRIPTION
The syntax name for a `style.scss` file is `SCSS` not `Sass` so Dash was just doing a global search. This fixes that so that both `Sass` and `SCSS` search the same docsets.