### PR TITLE
Add MagicPython to grammar-map

### DIFF
--- a/lib/grammar-map.coffee
+++ b/lib/grammar-map.coffee
@@ -100,6 +100,20 @@ objectiveC = [
   'manpages'
 ]
 
+python = [
+  'python',
+  'django',
+  'twisted',
+  'sphinx',
+  'flask',
+  'tornado',
+  'sqlalchemy',
+  'numpy',
+  'scipy',
+  'salt',
+  'cvp'
+]
+
 module.exports =
   'ActionScript': [
     'actionscript'
@@ -201,6 +215,7 @@ module.exports =
   'GitHub Markdown': [
     'markdown'
   ]
+  'MagicPython': python
   'Objective-C': objectiveC
   'Objective-C++': [
     'cpp',
@@ -220,19 +235,7 @@ module.exports =
   'Puppet': [
     'puppet'
   ]
-  'Python': [
-    'python',
-    'django',
-    'twisted',
-    'sphinx',
-    'flask',
-    'tornado',
-    'sqlalchemy',
-    'numpy',
-    'scipy',
-    'salt',
-    'cvp'
-  ]
+  'Python': python
   'R': [
     'r'
   ]


### PR DESCRIPTION
Thanks for the great plugin. This adds support for MagicPython (alternative syntax highlighter) to use the same lookups as standard Python.