### PR TITLE
Add Babel ES6 JavaScript to grammar map

### DIFF
--- a/lib/grammar-map.coffee
+++ b/lib/grammar-map.coffee
@@ -118,6 +118,7 @@ module.exports =
   'ActionScript': [
     'actionscript'
   ]
+  'Babel ES6 JavaScript': js
   'Boo': [
     'unity3d'
   ]


### PR DESCRIPTION
This should search same docs as javascript.

fixes https://github.com/blakeembrey/atom-dash/issues/45